### PR TITLE
Fix deployment workflow

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,6 +1,8 @@
 name: Deploy
 
-on: release
+on:
+  release:
+    types: [published]
 
 jobs:
   deploy:


### PR DESCRIPTION
Previous definition of workflow was triggering a deployment
any time actions were made on a release (edit it, delete it, create it...)

https://github.community/t/action-run-being-trigger-multiple-times/16144

We just want to deploy when a new release is created